### PR TITLE
fix: dispose editor on element unmount

### DIFF
--- a/core/src/index.tsx
+++ b/core/src/index.tsx
@@ -86,13 +86,6 @@ function MonacoEditor(props: MonacoEditorProps, ref: React.ForwardedRef<RefEdito
       $editor.current.setValue(val);
     }
   }, [val])
-  useEffect(() => {
-    return () => {
-      if($editor.current) {
-        $editor.current.dispose()
-      }
-    }
-  }, []);
 
   useEffect(() => {
     if (options.theme) {
@@ -162,6 +155,11 @@ function MonacoEditor(props: MonacoEditorProps, ref: React.ForwardedRef<RefEdito
           throw new Error('Failed to load font codicon!!');
         }
       });
+    } else {
+      if ($editor.current) {
+        $editor.current.dispose();
+        $editor.current = undefined;
+      }
     }
   }, []);
 


### PR DESCRIPTION
## Summary
Move dispose to `refElement` function.

The dispose will now be called when the component in unmounted instead (when `node` === `null`).
 
This allow component to work in `React.StrictMode` where `useEffect` is called twice


## Related issue

close #183

